### PR TITLE
timer: initial

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -30,9 +30,10 @@ build build/cgu.o: cc src/cgu.c
 build build/uart.o: cc src/uart.c
 build build/scu.o: cc src/scu.c
 build build/gpio.o: cc src/gpio.c
+build build/timer.o: cc src/timer.c
 
 # elf binary
-build kernel.elf: ld build/main.o build/start.o build/vector_table.o build/exceptions.o build/cgu.o build/uart.o build/scu.o build/gpio.o build/default_handlers.o
+build kernel.elf: ld build/main.o build/start.o build/vector_table.o build/exceptions.o build/default_handlers.o build/cgu.o build/uart.o build/scu.o build/gpio.o build/timer.o
 
 #build/lwip.o build/libc.o
 

--- a/include/bits/timer.h
+++ b/include/bits/timer.h
@@ -1,0 +1,17 @@
+/* TCR */
+#define CEN (1 << 0)
+#define CRST (1 << 1)
+
+/* MCR */
+#define MR0I (1 << 0)
+#define MR0R (1 << 1)
+#define MR0S (1 << 2)
+#define MR1I (1 << 3)
+#define MR1R (1 << 4)
+#define MR1S (1 << 5)
+#define MR2I (1 << 6)
+#define MR2R (1 << 7)
+#define MR2S (1 << 8)
+#define MR3I (1 << 9)
+#define MR3R (1 << 10)
+#define MR3S (1 << 11)

--- a/include/registers/timer.h
+++ b/include/registers/timer.h
@@ -1,0 +1,39 @@
+#include <stdint.h>
+
+#pragma once
+
+/* timer */
+struct timer {
+  /* interrupt register */
+  volatile uint32_t IR;
+  /* timer control register */
+  volatile uint32_t TCR;
+  /* timer counter */
+  volatile uint32_t TC;
+  /* prescale register */
+  volatile uint32_t PR;
+  /* prescale counter */
+  volatile uint32_t PC;
+  /* match control register */
+  volatile uint32_t MCR;
+  /* match register */
+  volatile uint32_t MR[4];
+  /* capture control register */
+  volatile uint32_t CCR;
+  /* capture register */
+  volatile uint32_t CR[4];
+  /* external match register */
+  volatile uint32_t EMR;
+  volatile uint32_t _pad_a[12];
+  /* count control register */
+  volatile uint32_t CTCR;
+};
+
+#define TIMER0_BASE 0x40084000
+#define TIMER0 ((struct timer *const) TIMER0_BASE)
+#define TIMER1_BASE 0x40085000
+#define TIMER1 ((struct timer *const) TIMER1_BASE)
+#define TIMER2_BASE 0x400C3000
+#define TIMER2 ((struct timer *const) TIMER2_BASE)
+#define TIMER3_BASE 0x400C4000
+#define TIMER3 ((struct timer *const) TIMER3_BASE)

--- a/src/main.c
+++ b/src/main.c
@@ -8,6 +8,8 @@
 #include "scu.h"
 #include "registers/gpio.h"
 #include "gpio.h"
+#include "registers/timer.h"
+#include "timer.h"
 
 #include "board/lpcx_v3.h"
 
@@ -36,9 +38,14 @@ void main(void)
   uart_enable_interrupt(UART0);
   gpio_init();
 
+  timer_delay(TIMER0, 1000000);
+
   /* fixme: map uart to irqn */
   NVIC_SetPriority(USART0_IRQn, 1);
   NVIC_EnableIRQ(USART0_IRQn);
+
+  NVIC_SetPriority(TIMER0_IRQn, 1);
+  NVIC_EnableIRQ(TIMER0_IRQn);
 
   __enable_irq();
 
@@ -69,4 +76,11 @@ void _uart0(void)
   (void)status1;
 
   return;
+}
+
+void _timer0(void)
+{
+  TIMER0->IR = (1 << 0);
+
+  GPIO->NOT[3] = (1 << 7);
 }

--- a/src/timer.c
+++ b/src/timer.c
@@ -1,0 +1,21 @@
+#include "registers/timer.h"
+#include "bits/timer.h"
+
+void
+timer_delay(struct timer *const timer, uint32_t usec)
+{
+  /* interrupt on MR0 */
+  timer->MCR = MR0I | MR0R;
+
+  /* prescale 204MHz IRC @ 1µs */
+  timer->PR = 204;
+
+  /* timer match value */
+  timer->MR[0] = usec;
+
+  /* reset and enable counter */
+  timer->PC = 0;
+  timer->TC = 0;
+
+  timer->TCR = CEN;
+}

--- a/src/timer.h
+++ b/src/timer.h
@@ -1,0 +1,6 @@
+#include <stdint.h>
+
+#include "registers/timer.h"
+
+void
+timer_delay(struct timer *const timer, uint32_t usec);


### PR DESCRIPTION
replaces #9 

The clock probably isn't set correctly, because the expected match/reset rate
does not match the observed rate.